### PR TITLE
crates/tailpam: CertDomains is nullable

### DIFF
--- a/crates/tailpam/src/tailscale.rs
+++ b/crates/tailpam/src/tailscale.rs
@@ -53,7 +53,7 @@ pub struct Status {
     magic_dns_suffix: String,
 
     #[serde(rename = "CertDomains")]
-    cert_domains: Vec<String>,
+    cert_domains: Option<Vec<String>>,
 
     #[serde(rename = "Peer")]
     pub peer: HashMap<String, Peer>,


### PR DESCRIPTION
The status JSON response was failing to deserialize for me because this field was unexpectedly null :^)